### PR TITLE
Fix the usb packet field name for recent versions of wireshark

### DIFF
--- a/ftdi2vcd.lua
+++ b/ftdi2vcd.lua
@@ -136,7 +136,7 @@ end
 
 function FTDI:cmd_2a()
    local len = self.o:read_uint8() + 1
-   local inval = self.i:read_uint8()
+   local inval = bit32.rshift(self.i:read_uint8(), 8 - len)
    self:comment("data in bits", len, "inval", inval)
    self:clock(len, {TDO = inval})
 end

--- a/ftdi2vcd.lua
+++ b/ftdi2vcd.lua
@@ -18,7 +18,7 @@
 
 
 local usb_transfer_type_f = Field.new("usb.transfer_type")
-local usb_direction_f = Field.new("usb.endpoint_number.direction")
+local usb_direction_f = Field.new("usb.endpoint_address.direction")
 local usb_capdata_f = Field.new("usb.capdata")
 
 

--- a/ftdi2vcd.lua
+++ b/ftdi2vcd.lua
@@ -119,7 +119,7 @@ function FTDI:cmd_19()
 end
 
 function FTDI:cmd_1b()
-   local len = self.o:read_uint8()
+   local len = self.o:read_uint8() + 1
    local outval = self.o:read_uint8()
    self:comment("data out bits", len, "outval", outval)
    self:clock(len, {TDI = outval})

--- a/ftdi_dump.lua
+++ b/ftdi_dump.lua
@@ -18,7 +18,7 @@
 
 
 local usb_transfer_type_f = Field.new("usb.transfer_type")
-local usb_direction_f = Field.new("usb.endpoint_number.direction")
+local usb_direction_f = Field.new("usb.endpoint_address.direction")
 local usb_capdata_f = Field.new("usb.capdata")
 
 


### PR DESCRIPTION
I found this library very useful, but had to make some changes to get it to work with the most recent version of wireshark.  My guess is that they changed the USB field name at some point.